### PR TITLE
3 - Automatically handle record dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,24 @@ A simple Unit of Work implementation in the Salesforce Apex programming language
 
 ## Key Features
 
-* **Ordered DML Execution**: The class enforces a specific sequence for DML operations based on a provided `SObjectType` list, ensuring that parent records are processed before children during insertions and updates. Deletions are automatically handled in the reverse order to maintain referential integrity.
-* **Standard Record Registration**: Provides explicit methods for registering records to be processed during the commit phase, including `registerNew` for insertions, `registerDirty` for updates, and `registerDeleted` for removals.
-* **Intelligent Dirty Record Merging**: If a record is registered as "dirty" multiple times within the same transaction, the implementation merges the field values, with the most recent registration taking precedence.
-* **Relationship Management**: Includes a `registerRelationship` method that allows developers to link records that do not yet have IDs (e.g., a new Contact linked to a new Account). The Unit of Work resolves these foreign keys automatically during the commit process.
-* **Security and Permission Bypasses**: Offers granular control over Salesforce security by allowing specific `SObjectType` bypasses for sharing rules (`bypassSharing`) or CRUD and Field Level Security (`bypassPermissions`).
-* **Transactional Integrity**: Utilises Database Savepoints to ensure atomicity. If any DML operation fails during `commitWork`, the entire transaction is rolled back to its pre-commit state.
-* **Custom Exception Handling**: Features a hierarchy of custom exceptions, including `ValidationException`, `CommitException`, and `RelationshipException`, to provide clear feedback on failure points.
+* **Automatic DML Ordering**: Rather than requiring a pre-defined list of `SObjectType`s, the Unit of Work automatically determines the correct insert, update and delete order at commit time using a graph-based topological sort, derived from the relationships you register. Parent records are always inserted before their children; deletions happen in reverse order.
+* **Standard Record Registration**: Provides explicit methods for registering records to be processed during the commit phase: `registerNew` for insertions, `registerDirty` for updates, and `registerDeleted` for removals.
+* **Intelligent Dirty Record Merging**: If a record is registered as dirty multiple times within the same transaction, field values are merged and the most recent registration for each field takes precedence.
+* **Relationship Management**: The `registerRelationship` method links records that do not yet have IDs (e.g., a new `Contact` linked to a new `Account`). Foreign keys are resolved automatically at commit time once parent records have been inserted.
+* **Intra-SObject Relationship Support**: When records of the same `SObjectType` reference each other (e.g., `Account.ParentId`), the Unit of Work splits DML into dependency-ordered waves so parent records are always inserted first.
+* **Circular Relationship Support**: When two `SObjectType`s reference each other and only one relationship can be set at insert time, use `prioritiseRelationship( priorityField, secondaryField )` to declare which field can be deferred. The secondary relationship is applied as an update after both records have been inserted.
+* **Security and Permission Bypasses**: Offers granular, per-`SObjectType` control over sharing rules (`bypassSharing`) and CRUD/FLS permissions (`bypassPermissions`).
+* **Transactional Integrity**: Uses a Database Savepoint to ensure atomicity. Any DML failure during `commitWork` rolls back the entire transaction to its pre-commit state.
+* **Single-Use Enforcement**: Each `UnitOfWork` instance can only be committed once. Calling `commitWork` a second time throws a `ValidationException` immediately.
+* **Custom Exceptions**: A clear exception hierarchy: `ValidationException`, `CommitException`, and `RelationshipException` identifies exactly where a failure occurred and why.
 
 ## Usage Examples
 
-Here are some common usage scenarios for the `UnitOfWork` class.
-
 ### 1. Creating and Relating Records
-This example demonstrates how to create a new `Account` and a related `Contact` in a single transaction. The Unit of Work ensures the `Account` is inserted first and automatically populates the `AccountId` on the `Contact` before it is inserted.
+The Unit of Work automatically determines that `Account` must be inserted before `Contact` based on the registered relationship. No ordering list is required.
 
 ```apex
-UnitOfWork uow = new UnitOfWork( new List<SObjectType>{ Account.SObjectType, Contact.SObjectType } );
+UnitOfWork uow = new UnitOfWork();
 
 Account newAccount = new Account( Name = 'Acme Corp' );
 uow.registerNew( newAccount );
@@ -29,84 +30,125 @@ Contact newContact = new Contact( LastName = 'Doe' );
 uow.registerNew( newContact );
 uow.registerRelationship( newContact, Contact.AccountId, newAccount );
 
-uow.commitWork();
+uow.commitWork(); // Account inserted first, then Contact with AccountId populated
 ```
 
 ### 2. Updating Records
-Use `registerDirty` to update existing records. The class intelligently merges multiple updates to the same record.
+Use `registerDirty` to update existing records. Multiple updates to the same record are merged into a single DML statement.
 
 ```apex
-UnitOfWork uow = new UnitOfWork( new List<SObjectType>{ Account.SObjectType } );
+UnitOfWork uow = new UnitOfWork();
 
-// Imagine an Account with an existing Id
-Account existingAcct = new Account(Id = '001xx0000000001AAA', Name = 'Updated Name');
-uow.registerDirty(existingAcct);
+Account existingAcct = new Account( Id = '001xx0000000001AAA', Name = 'Updated Name' );
+uow.registerDirty( existingAcct );
 
-// If another part of your code registers an update to the same record, changes are merged
-Account sameAcctUpdate = new Account(Id = '001xx0000000001AAA', Industry = 'Technology');
-uow.registerDirty(sameAcctUpdate);
+// Another part of your code updates the same record — changes are merged
+Account sameAcctUpdate = new Account( Id = '001xx0000000001AAA', Industry = 'Technology' );
+uow.registerDirty( sameAcctUpdate );
 
-uow.commitWork(); // Only 1 DML update will occur with both Name and Industry updated
+uow.commitWork(); // Single update DML with both Name and Industry set
 ```
 
 ### 3. Deleting Records
-Records can be marked for deletion. The Unit of Work automatically processes deletions in the reverse order of the list provided in the constructor to respect referential integrity.
+Records can be marked for deletion. The Unit of Work automatically processes deletions in reverse dependency order.
 
 ```apex
-UnitOfWork uow = new UnitOfWork( new List<SObjectType>{ Account.SObjectType, Contact.SObjectType } );
+UnitOfWork uow = new UnitOfWork();
 
-Contact contactToDelete = new Contact(Id = '003xx0000000001AAA');
-Account accountToDelete = new Account(Id = '001xx0000000001AAA');
+Contact contactToDelete = new Contact( Id = '003xx0000000001AAA' );
+Account accountToDelete = new Account( Id = '001xx0000000001AAA' );
 
 uow.registerDeleted( accountToDelete );
 uow.registerDeleted( contactToDelete );
 
-// Deletions happen in reverse order: Contacts are deleted before Accounts
-uow.commitWork();
+uow.commitWork(); // Contacts deleted before Accounts with the order derived automatically
 ```
 
-### 4. Bypassing Permissions and Sharing
-You can selectively bypass user permissions (CRUD/FLS) and sharing rules (record visibility) for specific `SObjectType`s during the commit phase. Avoid bypassing permissions or sharing unless absolutely necessary.
+### 4. Intra-SObject Hierarchies
+When records of the same SObjectType reference each other, the Unit of Work splits inserts into waves automatically. No special configuration is needed.
 
 ```apex
-UnitOfWork uow = new UnitOfWork( new List<SObjectType>{ Account.SObjectType } );
+UnitOfWork uow = new UnitOfWork();
 
-// Execute DML for Accounts regardless of the user's sharing rules
-uow.bypassSharing( Account.SObjectType );
+Account parentAccount = new Account( Name = 'Parent' );
+Account childAccount  = new Account( Name = 'Child' );
 
-// Execute DML for Accounts regardless of the user's object/field permissions (system mode)
-uow.bypassPermissions( Account.SObjectType );
+uow.registerNew( parentAccount );
+uow.registerNew( childAccount );
+uow.registerRelationship( childAccount, Account.ParentId, parentAccount );
 
-Account exampleAccount = new Account( Name = 'Example account' );
+uow.commitWork(); // Wave 1: parentAccount inserted. Wave 2: childAccount inserted with ParentId set.
+```
+
+### 5. Breaking Circular Relationships
+When two records reference each other and both cannot be set at insert time, call `prioritiseRelationship` to declare which field should be deferred to a post-insert update.
+
+```apex
+UnitOfWork uow = new UnitOfWork();
+
+Account newAccount = new Account( Name = 'Acme' );
+Contact newContact = new Contact( LastName = 'Doe' );
+
+uow.registerNew( newAccount );
+uow.registerNew( newContact );
+
+// Contact.AccountId is the priority relationship (set at insert time)
+// Account.Primary_Contact__c is the secondary relationship (deferred to an update)
+uow.prioritiseRelationship( Contact.AccountId, Account.Primary_Contact__c );
+
+uow.registerRelationship( newContact, Contact.AccountId,           newAccount );
+uow.registerRelationship( newAccount, Account.Primary_Contact__c,  newContact );
+
+uow.commitWork();
+// 1. Account inserted (no circular field yet)
+// 2. Contact inserted with AccountId = newAccount.Id
+// 3. Account updated with Primary_Contact__c = newContact.Id
+```
+
+### 6. Bypassing Permissions and Sharing
+Selectively bypass sharing rules or CRUD/FLS for specific `SObjectType`s. Use sparingly.
+
+```apex
+UnitOfWork uow = new UnitOfWork();
+
+uow.bypassSharing( Account.SObjectType );     // Ignore sharing rules for Accounts
+uow.bypassPermissions( Account.SObjectType ); // Ignore CRUD/FLS for Accounts
+
+Account exampleAccount = new Account( Name = 'Example' );
 uow.registerNew( exampleAccount );
 
 uow.commitWork();
 ```
 
-## Test Coverage and Scenarios
-
-The test class ensures the robustness of the implementation by verifying both "happy path" and "edge case" scenarios:
-
-**Constructor Validation**:
-* Throws a `ValidationException` if the class is instantiated with a null or empty list of `SObjectTypes`.
-* Confirms the internal operation order is correctly cloned and reversed upon instantiation.
-
+## Test Coverage Scenarios
 
 **Registration Safeguards**:
-* **registerNew**: Prevents registering null records, records that already possess an ID, or records of an `SObjectType` not defined in the initial operation order.
-* **registerDirty/Deleted**: Validates that records must have an ID and must be of a supported `SObjectType`.
+* `registerNew`: rejects null records and records that already have an Id.
+* `registerDirty`: rejects null records and records without an Id.
+* `registerDeleted`: rejects null records, records without an Id, and records that are already the parent of a registered relationship (prevents a dangling lookup after deletion).
+* `registerRelationship`: rejects null arguments, fields belonging to a different `SObjectType` than the record, a field already registered for the same record, and parent records already registered for deletion.
+* `prioritiseRelationship`: rejects null arguments for either field.
 
+**Merging Logic**:
+* Multiple `registerDirty` calls on the same record Id correctly merge fields, with the most recent registration winning per field.
 
-**Merging Logic Verification**:
-* Specifically tests that multiple `registerDirty` calls on the same record ID correctly merge fields and handle null values as intended.
+**Commit Behaviour**:
+* A Unit of Work with no registrations issues zero DML statements.
+* A `commitWork` call on an already-committed instance throws a `ValidationException` immediately (before any DML).
+* Any DML failure rolls back the entire transaction via a Savepoint.
+* Hard referential integrity failures (e.g. deleting an Account with an active Contract) roll back and throw a `CommitException`.
 
+**Graph-Based Ordering**:
+* Records with inter-type relationships are inserted in the correct dependency order regardless of registration order.
+* Intra-SObject relationships (e.g. `Account.ParentId`) split inserts into waves so parents precede children.
+* A circular inter-type dependency without a `prioritiseRelationship` call throws a `CommitException` wrapping a `RelationshipException`.
+* A circular intra-type dependency (e.g. Account A → Account B → Account A via `ParentId`) throws a `CommitException` wrapping a `RelationshipException`.
 
-**Relationship Integrity**:
-* Validates that relationship fields belong to the correct `SObjectType`.
-* Ensures the relationship field actually points to the `SObjectType` of the parent record.
-* Confirms successful registration of valid parent-child links.
+**Circular Relationships**:
+* `prioritiseRelationship` correctly defers the secondary field to a post-insert update for two new records.
+* The secondary relationship field is correctly merged with any dirty field changes when the source record was previously registered dirty (no double-update or field overwrite).
 
-
-* **Permission and Sharing Bypasses**:
-* Verifies that bypasses can only be registered for `SObjectTypes` included in the Unit of Work's scope.
-* Ensures null inputs for bypass methods are caught and handled via exceptions.
+**Permission and Sharing Bypasses**:
+* `bypassSharing` and `bypassPermissions` reject null inputs.
+* DML for a bypassed type executes in system mode regardless of the running user's permissions.
+* Permission failures for non-bypassed types trigger a rollback and a `CommitException`.

--- a/force-app/main/default/classes/UnitOfWork.cls
+++ b/force-app/main/default/classes/UnitOfWork.cls
@@ -37,6 +37,7 @@ public with sharing class UnitOfWork
     @testVisible private Set<SobjectType> sobjectTypesToBypassSharing = new Set<SobjectType>();
     @testVisible private Set<SobjectType> sobjectTypesToBypassPermissions = new Set<SobjectType>();
     @testVisible private Set<SObjectField> secondaryFields = new Set<SObjectField>();
+    @testVisible private Boolean committed = false;
 
     public UnitOfWork() {}
 
@@ -61,6 +62,7 @@ public with sharing class UnitOfWork
     public void registerDeleted( SObject record ) {
         validate( record != null, 'registerDeleted called with a null record' );
         validate( record.Id != null, 'registerDeleted called with a record that does not have an Id' );
+        validate( !isParentOfAnyRelationship( record ), 'registerDeleted called with a record that is the parent of a registered relationship' );
 
         deletedRecord( record );
     }
@@ -75,6 +77,8 @@ public with sharing class UnitOfWork
         DescribeFieldResult fieldDescribe = relationshipField.getDescribe();
 
         validate( fieldDescribe.getSobjectType() == recordSobjectType, 'registerRelationship called with a relationship field from a different SobjectType than the record SobjectType' );
+        validate( !relationships.hasRelationship( record, relationshipField ), 'registerRelationship called with a relationship field that has already been registered for this record' );
+        validate( !isRegisteredForDeletion( parentRecord ), 'registerRelationship called with a parent record that has been registered for deletion' );
 
         relationships.addRelationship( record, relationshipField, parentRecord );
     }
@@ -104,6 +108,8 @@ public with sharing class UnitOfWork
 
     // Commits all the changes to the database.
     public void commitWork() {
+        validate( !committed, 'commitWork has already been called on this UnitOfWork instance' );
+
         Savepoint preCommitSavepoint = Database.setSavepoint();
 
         try {
@@ -132,6 +138,8 @@ public with sharing class UnitOfWork
             for ( SObjectType thisSobjectType : reversedOrderSobjectTypes ) {
                 deleteRecordsForSobjectType( thisSobjectType );
             }
+
+            committed = true;
         }
         catch ( DmlException ex ) {
             Database.rollback( preCommitSavepoint );
@@ -290,9 +298,11 @@ public with sharing class UnitOfWork
             }
         }
 
+        Integer recordsPlacedInWaves = 0;
         List<List<SObject>> waves = new List<List<SObject>>();
         while ( !currentWave.isEmpty() ) {
             waves.add( currentWave );
+            recordsPlacedInWaves += currentWave.size();
             List<SObject> nextWave = new List<SObject>();
             for ( SObject thisRecord : currentWave ) {
                 for ( SObject thisChildRecord : childrenByRecord.get( thisRecord ) ) {
@@ -305,6 +315,11 @@ public with sharing class UnitOfWork
             }
             currentWave = nextWave;
         }
+
+        if ( recordsPlacedInWaves != records.size() ) {
+            throw new RelationshipException( 'Circular intra-type relationship detected between records of the same SObject type. Records of the same SObject type cannot have circular dependencies.' );
+        }
+
         return waves;
     }
 
@@ -440,6 +455,29 @@ public with sharing class UnitOfWork
         deletedRecordIdsBySobjectType.get( recordSobjectType ).add( record.Id );
     }
 
+    private Boolean isRegisteredForDeletion( SObject record ) {
+        if ( record.Id == null ) {
+            return false;
+        }
+        Set<Id> deletedIds = deletedRecordIdsBySobjectType.get( record.getSObjectType() );
+        return deletedIds != null && deletedIds.contains( record.Id );
+    }
+
+    private Boolean isParentOfAnyRelationship( SObject record ) {
+        if ( record.Id == null ) {
+            return false;
+        }
+        SObjectType recordType = record.getSObjectType();
+        for ( SObjectType thisChildSobjectType : relationships.relationshipsBySobjectType.keySet() ) {
+            for ( Relationship thisRelationship : relationships.relationshipsBySobjectType.get( thisChildSobjectType ) ) {
+                if ( thisRelationship.getParentRecord().getSObjectType() == recordType && thisRelationship.getParentRecord().Id == record.Id ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private class Relationships {
         @testVisible private Map<SobjectType, List<Relationship>> relationshipsBySobjectType = new Map<SobjectType, List<Relationship>>();
 
@@ -451,6 +489,19 @@ public with sharing class UnitOfWork
             }
 
             relationshipsBySobjectType.get( recordSobjectType ).add( new Relationship( record, relationshipField, parentRecord ) );
+        }
+
+        public Boolean hasRelationship( SObject record, SObjectField relationshipField ) {
+            SobjectType recordSobjectType = record.getSObjectType();
+            if ( !relationshipsBySobjectType.containsKey( recordSobjectType ) ) {
+                return false;
+            }
+            for ( Relationship thisRelationship : relationshipsBySobjectType.get( recordSobjectType ) ) {
+                if ( thisRelationship.getRecord() == record && thisRelationship.getRelationshipField() == relationshipField ) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // Sets the lookup fields for the given set of records using only priority (non-secondary) relationships.

--- a/force-app/main/default/classes/UnitOfWorkTest.cls
+++ b/force-app/main/default/classes/UnitOfWorkTest.cls
@@ -307,6 +307,76 @@ private class UnitOfWorkTest {
     }
 
     @isTest
+    private static void registerRelationship_whenSameFieldRegisteredTwiceForSameRecord_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
+        Account account1 = new Account( Name = 'Account 1' );
+        Account account2 = new Account( Name = 'Account 2' );
+
+        unitOfWork.registerRelationship( testContact, Contact.AccountId, account1 );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerRelationship( testContact, Contact.AccountId, account2 );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerRelationship, when the same field is registered twice for the same record, should throw an exception' );
+        Assert.areEqual( 'registerRelationship called with a relationship field that has already been registered for this record', thrownException.getMessage(), 'registerRelationship, when the same field is registered twice for the same record, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerRelationship_whenParentRecordAlreadyRegisteredForDeletion_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
+        Account parentAccount = new Account( Id = '001000000000000', Name = 'Parent Account' );
+
+        unitOfWork.registerDeleted( parentAccount );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerRelationship( testContact, Contact.AccountId, parentAccount );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerRelationship, when the parent record has been registered for deletion, should throw an exception' );
+        Assert.areEqual( 'registerRelationship called with a parent record that has been registered for deletion', thrownException.getMessage(), 'registerRelationship, when the parent record has been registered for deletion, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerDeleted_whenRecordIsParentOfRegisteredRelationship_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
+        Account parentAccount = new Account( Id = '001000000000000', Name = 'Parent Account' );
+
+        unitOfWork.registerRelationship( testContact, Contact.AccountId, parentAccount );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerDeleted( parentAccount );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerDeleted, when the record is the parent of a registered relationship, should throw an exception' );
+        Assert.areEqual( 'registerDeleted called with a record that is the parent of a registered relationship', thrownException.getMessage(), 'registerDeleted, when the record is the parent of a registered relationship, should throw a ValidationException' );
+    }
+
+    @isTest
     private static void bypassSharing_whenCalledWithNullSobjectType_throwsValidationException() {
         UnitOfWork unitOfWork = new UnitOfWork();
         SObjectType nullSobjectType;
@@ -371,6 +441,46 @@ private class UnitOfWorkTest {
     }
 
     @isTest
+    private static void prioritiseRelationship_whenCalledWithNullPriorityField_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        SObjectField nullField;
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.prioritiseRelationship( nullField, Contact.AccountId );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'prioritiseRelationship, when called with a null priorityField, should throw an exception' );
+        Assert.areEqual( 'prioritiseRelationship called with a null priorityField', thrownException.getMessage(), 'prioritiseRelationship, when called with a null priorityField, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void prioritiseRelationship_whenCalledWithNullSecondaryField_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        SObjectField nullField;
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.prioritiseRelationship( Contact.AccountId, nullField );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'prioritiseRelationship, when called with a null secondaryField, should throw an exception' );
+        Assert.areEqual( 'prioritiseRelationship called with a null secondaryField', thrownException.getMessage(), 'prioritiseRelationship, when called with a null secondaryField, should throw a ValidationException' );
+    }
+
+    @isTest
     private static void commitWork_whenCalledWithNoRegistrations_issuesNoDmlStatements() {
         UnitOfWork unitOfWork = new UnitOfWork();
 
@@ -383,6 +493,86 @@ private class UnitOfWorkTest {
         Integer dmlStatementsIssuedAfter = Limits.getDmlStatements();
 
         Assert.areEqual( dmlStatementsIssuedBefore, dmlStatementsIssuedAfter, 'commitWork, when called with no registrations, should issue no Dml statements' );
+    }
+
+    @isTest
+    private static void commitWork_whenCalledTwice_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        unitOfWork.commitWork();
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.commitWork();
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'commitWork, when called twice on the same instance, should throw an exception on the second call' );
+        Assert.areEqual( 'commitWork has already been called on this UnitOfWork instance', thrownException.getMessage(), 'commitWork, when called twice, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void commitWork_whenInterTypeCircularRelationshipsRegisteredWithoutPrioritise_throwsCommitException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+
+        SobjectField contactLookupOnAccount = Account.Site;
+
+        Account testAccount = new Account( Name = 'Test Account' );
+        Contact testContact = new Contact( FirstName = 'Test', LastName = 'Contact' );
+
+        unitOfWork.registerNew( testAccount );
+        unitOfWork.registerNew( testContact );
+
+        // Both relationships are registered with neither marked as secondary — this creates an unresolvable cycle
+        unitOfWork.registerRelationship( testContact, Contact.AccountId, testAccount );
+        unitOfWork.registerRelationship( testAccount, contactLookupOnAccount, testContact );
+
+        UnitOfWork.CommitException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.commitWork();
+        }
+        catch ( UnitOfWork.CommitException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'commitWork, when inter-type circular relationships are registered without prioritiseRelationship, should throw an exception' );
+        Assert.isTrue( thrownException.getMessage().contains( 'Circular relationship detected between SObject types' ), 'commitWork, when inter-type circular relationships are registered without prioritiseRelationship, should throw a CommitException with a useful message' );
+    }
+
+    @isTest
+    private static void commitWork_whenIntraSobjectCircularRelationshipRegistered_throwsCommitException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+
+        Account accountA = new Account( Name = 'Account A' );
+        Account accountB = new Account( Name = 'Account B' );
+
+        unitOfWork.registerNew( accountA );
+        unitOfWork.registerNew( accountB );
+
+        // A → B → A creates an unresolvable intra-type cycle
+        unitOfWork.registerRelationship( accountA, Account.ParentId, accountB );
+        unitOfWork.registerRelationship( accountB, Account.ParentId, accountA );
+
+        UnitOfWork.CommitException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.commitWork();
+        }
+        catch ( UnitOfWork.CommitException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'commitWork, when an intra-SObject circular relationship is registered, should throw an exception' );
+        Assert.isTrue( thrownException.getMessage().contains( 'Circular intra-type relationship detected' ), 'commitWork, when an intra-SObject circular relationship is registered, should throw a CommitException with a useful message' );
     }
 
     @isTest


### PR DESCRIPTION
# Automatically handle record dependencies

Closes #3

## Summary

Removes the requirement to pass an ordered list of `SObjectType`s to the `UnitOfWork` constructor and replaces it with a fully automatic, graph-based approach to determining DML order. This makes the Unit of Work significantly more capable, removing the two main classes of relationship scenario it previously could not handle.

## What changed

### UnitOfWork.cls

**Removed**
- `UnitOfWork(List<SObjectType>)` constructor, `sobjectTypeOperationOrder` field, and all `sobjectTypeAllowed` validation logic

**Added**
- Single no-argument constructor: `new UnitOfWork()`
- `prioritiseRelationship(SObjectField priorityField, SObjectField secondaryField)` — allows the developer to break a circular dependency by declaring which lookup field should be deferred to a post-insert update
- Graph-based `commitWork()` algorithm:
  - **Topological sort of SObject types** (Kahn's algorithm) using registered priority relationships as dependency edges — determines insert order automatically
  - **Wave splitting for intra-type inserts** — when records of the same `SObjectType` reference each other (e.g. `Account.ParentId`), records are split into ordered waves so parents are always inserted before children
  - **Secondary relationship deferral** — after all inserts, secondary relationship fields are merged into dirty records and committed in a single update DML per type, correctly coalescing with any other field changes on the same record
  - **Priority relationships for dirty records** — a dedicated pass before the update loop applies registered priority relationships to dirty (pre-existing) records, mirroring what insert waves do for new records
- **Defensive guards** (each throws an appropriately typed exception at the earliest possible point):
  - Double-commit: `commitWork` on an already-committed instance throws `ValidationException` before a Savepoint is even set
  - Duplicate relationship field for the same record → `ValidationException` from `registerRelationship`
  - Parent record registered for deletion while being used in a relationship → `ValidationException` from either `registerRelationship` or `registerDeleted`, whichever is called second
  - Unresolvable inter-type circular dependency (no `prioritiseRelationship` call) → `RelationshipException` (surfaced as `CommitException`)
  - Unresolvable intra-type circular dependency → `RelationshipException` (surfaced as `CommitException`)

### UnitOfWorkTest.cls

**Removed** — tests tied to the now-deleted constructor and `sobjectTypeAllowed` validations (9 tests):
- Constructor null/empty argument tests
- `registerNew/Dirty/Deleted` "not in sobjectTypeOperationOrder" tests
- `bypassSharing/Permissions` "not in sobjectTypeOperationOrder" tests
- `commitWork` incompatible-order test

**Updated** — all remaining constructor calls replaced with `new UnitOfWork()`

**Added** — 9 new tests:
| Test | Scenario |
|---|---|
| `commitWork_whenIntraSobjectRelationshipRegistered_*` | Wave-split intra-type inserts |
| `commitWork_whenCircularRelationshipsRegistered_*` | `prioritiseRelationship` with two new records |
| `commitWork_whenCircularRelationshipsRegisteredWithDirtyRecord_*` | Secondary field correctly merged into dirty record |
| `prioritiseRelationship_whenCalledWithNullPriorityField_*` | Null guard |
| `prioritiseRelationship_whenCalledWithNullSecondaryField_*` | Null guard |
| `registerRelationship_whenSameFieldRegisteredTwiceForSameRecord_*` | Duplicate field guard |
| `registerRelationship_whenParentRecordAlreadyRegisteredForDeletion_*` | Parent-deleted conflict |
| `registerDeleted_whenRecordIsParentOfRegisteredRelationship_*` | Parent-deleted conflict (other direction) |
| `commitWork_whenCalledTwice_*` | Double-commit guard |
| `commitWork_whenInterTypeCircularRelationshipsRegisteredWithoutPrioritise_*` | Unresolvable inter-type cycle |
| `commitWork_whenIntraSobjectCircularRelationshipRegistered_*` | Unresolvable intra-type cycle |

### README.md

Rewrote Key Features, Usage Examples, and Test Coverage sections to reflect the new API. Added examples for intra-SObject hierarchies and circular relationships.

## Breaking changes

> [!IMPORTANT]
> The `UnitOfWork(List<SObjectType>)` constructor is removed. Any call site that previously passed an ordered type list must be updated to `new UnitOfWork()` with no arguments.