### PR TITLE
Add hard delete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple Unit of Work implementation in the Salesforce Apex programming language
 ## Key Features
 
 * **Automatic DML Ordering**: Rather than requiring a pre-defined list of `SObjectType`s, the Unit of Work automatically determines the correct insert, update and delete order at commit time using a graph-based topological sort, derived from the relationships you register. Parent records are always inserted before their children; deletions happen in reverse order for dependencies that have been explicitly registered with `registerRelationship`.
-* **Standard Record Registration**: Provides explicit methods for registering records to be processed during the commit phase: `registerNew` for insertions, `registerDirty` for updates, and `registerDeleted` for removals.
+* **Standard Record Registration**: Provides explicit methods for registering records to be processed during the commit phase: `registerNew` for insertions, `registerDirty` for updates, `registerDeleted` for soft deletions, and `registerPermanentlyDeleted` for hard deletions.
 * **Intelligent Dirty Record Merging**: If a record is registered as dirty multiple times within the same transaction, field values are merged and the most recent registration for each field takes precedence.
 * **Relationship Management**: The `registerRelationship` method links records that do not yet have IDs (e.g., a new `Contact` linked to a new `Account`). Foreign keys are resolved automatically at commit time once parent records have been inserted. This method is intentionally flexible and can also be used for simulated relationships, such as custom text fields that store another record's Id.
 * **Intra-SObject Relationship Support**: When records of the same `SObjectType` reference each other (e.g., `Account.ParentId`), the Unit of Work splits DML into dependency-ordered waves so parent records are always inserted first.
@@ -20,6 +20,7 @@ A simple Unit of Work implementation in the Salesforce Apex programming language
 * **Delete ordering is based on registered relationships**: The Unit of Work does not inspect org schema or infer dependency chains from describes during `commitWork`. If deletion order matters, register the relevant dependencies explicitly with `registerRelationship`.
 * **Simulated relationships are supported**: `registerRelationship` does not require the field to be a native Salesforce lookup. This allows patterns such as text fields that store record Ids to participate in the dependency graph.
 * **Dirty-then-delete is allowed**: A record may be registered as dirty and then deleted in the same Unit of Work. In that case the update is applied before the delete, which can be useful when business rules require a record to be moved into a deletable state first.
+* **Hard delete builds on standard delete semantics**: `registerPermanentlyDeleted` first performs a normal delete, then calls `Database.emptyRecycleBin()` for the registered records. This means the initial delete still enforces the configured access level and sharing behavior before those records are hard deleted.
 * **Intra-SObject dependency waves assume one same-type parent per registered field path**: Hierarchies such as parent/child/grandchild work correctly, but more complex cases where one record depends on multiple records of the same `SObjectType` through different fields are not currently supported.
 
 ## Usage Examples
@@ -87,7 +88,20 @@ uow.registerRelationship( childAccount, Account.ParentId, parentAccount );
 uow.commitWork(); // Wave 1: parentAccount inserted. Wave 2: childAccount inserted with ParentId set.
 ```
 
-### 5. Breaking Circular Relationships
+### 5. Permanently Deleting Records
+Use `registerPermanentlyDeleted` when records should be deleted and then removed from the recycle bin.
+
+```apex
+UnitOfWork uow = new UnitOfWork();
+
+Account accountToHardDelete = new Account( Id = '001xx0000000001AAA' );
+
+uow.registerPermanentlyDeleted( accountToHardDelete );
+
+uow.commitWork(); // Deletes the record, then calls Database.emptyRecycleBin() for that record
+```
+
+### 6. Breaking Circular Relationships
 When two records reference each other and both cannot be set at insert time, call `prioritiseRelationship` to declare which field should be deferred to a post-insert update.
 
 ```apex
@@ -112,7 +126,7 @@ uow.commitWork();
 // 3. Account updated with Primary_Contact__c = newContact.Id
 ```
 
-### 6. Bypassing Permissions and Sharing
+### 7. Bypassing Permissions and Sharing
 Selectively bypass sharing rules or CRUD/FLS for specific `SObjectType`s. Use sparingly.
 
 ```apex
@@ -133,6 +147,7 @@ uow.commitWork();
 * `registerNew`: rejects null records and records that already have an Id.
 * `registerDirty`: rejects null records and records without an Id.
 * `registerDeleted`: rejects null records, records without an Id, and records that are already the parent of a registered relationship (prevents a dangling lookup after deletion).
+* `registerPermanentlyDeleted`: rejects null records, records without an Id, and records that are already the parent of a registered relationship.
 * `registerRelationship`: rejects null arguments, fields belonging to a different `SObjectType` than the record, a field already registered for the same record, and parent records already registered for deletion.
 * `prioritiseRelationship`: rejects null arguments for either field.
 
@@ -144,6 +159,7 @@ uow.commitWork();
 * A `commitWork` call on an already-committed instance throws a `ValidationException` immediately (before any DML).
 * Any DML failure rolls back the entire transaction via a Savepoint.
 * Hard referential integrity failures (e.g. deleting an Account with an active Contract) roll back and throw a `CommitException`.
+* `registerPermanentlyDeleted` deletes the record and then invokes `Database.emptyRecycleBin()` as part of the same commit flow.
 
 **Graph-Based Ordering**:
 * Records with inter-type relationships are inserted in the correct dependency order regardless of registration order.
@@ -161,3 +177,4 @@ uow.commitWork();
 * `bypassPermissions` causes DML for that `SObjectType` to execute in `SYSTEM_MODE`, bypassing CRUD/FLS checks.
 * Permission failures for non-bypassed types trigger a rollback and a `CommitException`.
 * `bypassSharing` itself is not directly verified by the tests, because its behaviour depends on org sharing configuration and the package is intended to deploy cleanly even in environments where relevant objects are configured with public read/write access.
+* Hard delete tests verify that `Database.emptyRecycleBin()` reports success for registered records, rather than asserting immediate disappearance from `ALL ROWS`, because final physical purge timing is platform-managed.

--- a/force-app/main/default/classes/UnitOfWork.cls
+++ b/force-app/main/default/classes/UnitOfWork.cls
@@ -33,6 +33,8 @@ public with sharing class UnitOfWork
     @testVisible private Map<SObjectType, List<SObject>> newRecordsBySobjectType = new Map<SObjectType, List<SObject>>();
     @testVisible private Map<SObjectType, Map<Id, SObject>> dirtyRecordsBySobjectTypeAndRecordId = new Map<SObjectType, Map<Id, SObject>>();
     @testVisible private Map<SObjectType, Set<Id>> deletedRecordIdsBySobjectType = new Map<SObjectType, Set<Id>>();
+    @testVisible private Map<SObjectType, Set<Id>> permanentlyDeletedRecordIdsBySobjectType = new Map<SObjectType, Set<Id>>();
+    @testVisible private Set<Id> successfullyPermanentlyDeletedRecordIds = new Set<Id>();
     @testVisible private Relationships relationships = new Relationships();
     @testVisible private Set<SobjectType> sobjectTypesToBypassSharing = new Set<SobjectType>();
     @testVisible private Set<SobjectType> sobjectTypesToBypassPermissions = new Set<SobjectType>();
@@ -91,6 +93,24 @@ public with sharing class UnitOfWork
         validate( !records.isEmpty(), 'registerDeleted called with an empty records list' );
         for ( SObject thisRecord : records ) {
             registerDeleted( thisRecord );
+        }
+    }
+
+    // Registers a record as permanently deleted so that the unit of work will delete it and then empty it from the recycle bin on commit.
+    public void registerPermanentlyDeleted( SObject record ) {
+        validate( record != null, 'registerPermanentlyDeleted called with a null record' );
+        validate( record.Id != null, 'registerPermanentlyDeleted called with a record that does not have an Id' );
+        validate( !isParentOfAnyRelationship( record ), 'registerPermanentlyDeleted called with a record that is the parent of a registered relationship' );
+
+        permanentlyDeletedRecord( record );
+    }
+
+    // Registers a list of records as permanently deleted so that the unit of work will delete them and then empty them from the recycle bin on commit.
+    public void registerPermanentlyDeleted( List<SObject> records ) {
+        validate( records != null, 'registerPermanentlyDeleted called with a null records list' );
+        validate( !records.isEmpty(), 'registerPermanentlyDeleted called with an empty records list' );
+        for ( SObject thisRecord : records ) {
+            registerPermanentlyDeleted( thisRecord );
         }
     }
 
@@ -166,6 +186,9 @@ public with sharing class UnitOfWork
                 deleteRecordsForSobjectType( thisSobjectType );
             }
 
+            // Permanently delete records that were explicitly registered for hard deletion
+            permanentlyDeleteRegisteredRecords();
+
             committed = true;
         }
         catch ( DmlException ex ) {
@@ -190,6 +213,7 @@ public with sharing class UnitOfWork
         combinedSobjectTypes.addAll( newRecordsBySobjectType.keySet() );
         combinedSobjectTypes.addAll( dirtyRecordsBySobjectTypeAndRecordId.keySet() );
         combinedSobjectTypes.addAll( deletedRecordIdsBySobjectType.keySet() );
+        combinedSobjectTypes.addAll( permanentlyDeletedRecordIdsBySobjectType.keySet() );
         combinedSobjectTypes.addAll( relationships.relationshipsBySobjectType.keySet() );
 
         // Collect every type referenced across all three operation maps
@@ -435,7 +459,13 @@ public with sharing class UnitOfWork
     }
 
     private void deleteRecordsForSobjectType( SObjectType sobjectType ) {
-        Set<Id> recordIdsToDelete = deletedRecordIdsBySobjectType.get( sobjectType );
+        Set<Id> recordIdsToDelete = new Set<Id>();
+        if ( deletedRecordIdsBySobjectType.containsKey( sobjectType ) ) {
+            recordIdsToDelete.addAll( deletedRecordIdsBySobjectType.get( sobjectType ) );
+        }
+        if ( permanentlyDeletedRecordIdsBySobjectType.containsKey( sobjectType ) ) {
+            recordIdsToDelete.addAll( permanentlyDeletedRecordIdsBySobjectType.get( sobjectType ) );
+        }
 
         if ( recordIdsToDelete != null && !recordIdsToDelete.isEmpty() ) {
             AccessLevel accessLevel = sobjectTypesToBypassPermissions.contains( sobjectType ) ? AccessLevel.SYSTEM_MODE : AccessLevel.USER_MODE;
@@ -445,6 +475,47 @@ public with sharing class UnitOfWork
                 new WithoutSharing().deleteRecords( new List<Id>( recordIdsToDelete ), accessLevel );
             } else {
                 Database.delete( new List<Id>( recordIdsToDelete ), accessLevel );
+            }
+        }
+    }
+
+    private void permanentlyDeleteRegisteredRecords() {
+        List<SObject> recordsToPermanentlyDeleteWithSharing = new List<SObject>();
+        List<SObject> recordsToPermanentlyDeleteWithoutSharing = new List<SObject>();
+
+        for ( SObjectType thisSobjectType : permanentlyDeletedRecordIdsBySobjectType.keySet() ) {
+            Boolean bypassSharingForThisSobjectType = sobjectTypesToBypassSharing.contains( thisSobjectType );
+            for ( Id thisRecordId : permanentlyDeletedRecordIdsBySobjectType.get( thisSobjectType ) ) {
+                SObject recordStub = thisSobjectType.newSObject( thisRecordId );
+                if ( bypassSharingForThisSobjectType ) {
+                    recordsToPermanentlyDeleteWithoutSharing.add( recordStub );
+                } else {
+                    recordsToPermanentlyDeleteWithSharing.add( recordStub );
+                }
+            }
+        }
+
+        List<String> purgeErrors = new List<String>();
+        if ( !recordsToPermanentlyDeleteWithSharing.isEmpty() ) {
+            collectPermanentDeleteResults( Database.emptyRecycleBin( recordsToPermanentlyDeleteWithSharing ), purgeErrors );
+        }
+        if ( !recordsToPermanentlyDeleteWithoutSharing.isEmpty() ) {
+            collectPermanentDeleteResults( new WithoutSharing().permanentlyDeleteRecords( recordsToPermanentlyDeleteWithoutSharing ), purgeErrors );
+        }
+
+        if ( !purgeErrors.isEmpty() ) {
+            throw new CommitException( 'Permanent delete failed with errors:\n' + String.join( purgeErrors, '\n' ) );
+        }
+    }
+
+    private void collectPermanentDeleteResults( List<Database.EmptyRecycleBinResult> purgeResults, List<String> purgeErrors ) {
+        for ( Database.EmptyRecycleBinResult thisResult : purgeResults ) {
+            if ( thisResult.isSuccess() ) {
+                successfullyPermanentlyDeletedRecordIds.add( thisResult.getId() );
+            } else {
+                for ( Database.Error thisError : thisResult.getErrors() ) {
+                    purgeErrors.add( thisError.getMessage() );
+                }
             }
         }
     }
@@ -482,12 +553,27 @@ public with sharing class UnitOfWork
         deletedRecordIdsBySobjectType.get( recordSobjectType ).add( record.Id );
     }
 
+    private void permanentlyDeletedRecord( SObject record ) {
+        SobjectType recordSobjectType = record.getSObjectType();
+
+        if ( !permanentlyDeletedRecordIdsBySobjectType.containsKey( recordSobjectType ) ) {
+            permanentlyDeletedRecordIdsBySobjectType.put( recordSobjectType, new Set<Id>() );
+        }
+
+        permanentlyDeletedRecordIdsBySobjectType.get( recordSobjectType ).add( record.Id );
+    }
+
     private Boolean isRegisteredForDeletion( SObject record ) {
         if ( record.Id == null ) {
             return false;
         }
         Set<Id> deletedIds = deletedRecordIdsBySobjectType.get( record.getSObjectType() );
-        return deletedIds != null && deletedIds.contains( record.Id );
+        if ( deletedIds != null && deletedIds.contains( record.Id ) ) {
+            return true;
+        }
+
+        Set<Id> permanentlyDeletedIds = permanentlyDeletedRecordIdsBySobjectType.get( record.getSObjectType() );
+        return permanentlyDeletedIds != null && permanentlyDeletedIds.contains( record.Id );
     }
 
     private Boolean isParentOfAnyRelationship( SObject record ) {
@@ -559,6 +645,10 @@ public with sharing class UnitOfWork
 
         public void deleteRecords( List<Id> recordIds, AccessLevel accessLevel ) {
             Database.delete( recordIds, accessLevel );
+        }
+
+        public List<Database.EmptyRecycleBinResult> permanentlyDeleteRecords( List<SObject> records ) {
+            return Database.emptyRecycleBin( records );
         }
     }
 

--- a/force-app/main/default/classes/UnitOfWorkTest.cls
+++ b/force-app/main/default/classes/UnitOfWorkTest.cls
@@ -204,6 +204,58 @@ private class UnitOfWorkTest {
     }
 
     @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithNullRecord_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        SObject nullRecord;
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerPermanentlyDeleted( nullRecord );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerPermanentlyDeleted, when called with a null record, should throw an exception' );
+        Assert.areEqual( 'registerPermanentlyDeleted called with a null record', thrownException.getMessage(), 'registerPermanentlyDeleted, when called with a null record, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithRecordWithNullId_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Account accountWithNullId = new Account( Name = 'Account with Null Id' );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerPermanentlyDeleted( accountWithNullId );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerPermanentlyDeleted, when called with a record with a null Id, should throw an exception' );
+        Assert.areEqual( 'registerPermanentlyDeleted called with a record that does not have an Id', thrownException.getMessage(), 'registerPermanentlyDeleted, when called with a record with a null Id, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithRecordInSobjectTypeOperationOrder_registersRecord() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Account testAccount = new Account( Id = '001000000000000', Name = 'Test Account' );
+
+        Test.startTest();
+        unitOfWork.registerPermanentlyDeleted( testAccount );
+        Test.stopTest();
+
+        Assert.isTrue( unitOfWork.permanentlyDeletedRecordIdsBySobjectType.get( Account.SObjectType ).contains( testAccount.Id ), 'registerPermanentlyDeleted, when called with a record in the sobjectTypeOperationOrder, should register the record' );
+    }
+
+    @isTest
     private static void registerNew_whenCalledWithListOfRecords_registersAllRecords() {
         UnitOfWork unitOfWork = new UnitOfWork();
         Account accountA = new Account( Name = 'Account A' );
@@ -369,6 +421,61 @@ private class UnitOfWorkTest {
     }
 
     @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithListOfRecords_registersAllRecords() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Account accountA = new Account( Id = '001000000000001', Name = 'Account A' );
+        Account accountB = new Account( Id = '001000000000002', Name = 'Account B' );
+
+        Test.startTest();
+        unitOfWork.registerPermanentlyDeleted( new List<SObject>{ accountA, accountB } );
+        Test.stopTest();
+
+        Set<Id> registeredAccountIds = unitOfWork.permanentlyDeletedRecordIdsBySobjectType.get( Account.SObjectType );
+        Assert.areEqual( 2, registeredAccountIds.size(), 'registerPermanentlyDeleted, when called with a list of records, should register all records' );
+        Assert.isTrue( registeredAccountIds.contains( accountA.Id ), 'registerPermanentlyDeleted, when called with a list of records, should register the first record' );
+        Assert.isTrue( registeredAccountIds.contains( accountB.Id ), 'registerPermanentlyDeleted, when called with a list of records, should register the second record' );
+    }
+
+    @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithNullList_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        List<SObject> nullRecords;
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerPermanentlyDeleted( nullRecords );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerPermanentlyDeleted, when called with a null records list, should throw an exception' );
+        Assert.areEqual( 'registerPermanentlyDeleted called with a null records list', thrownException.getMessage(), 'registerPermanentlyDeleted, when called with a null records list, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerPermanentlyDeleted_whenCalledWithEmptyList_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerPermanentlyDeleted( new List<SObject>() );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerPermanentlyDeleted, when called with an empty records list, should throw an exception' );
+        Assert.areEqual( 'registerPermanentlyDeleted called with an empty records list', thrownException.getMessage(), 'registerPermanentlyDeleted, when called with an empty records list, should throw a ValidationException' );
+    }
+
+    @isTest
     private static void registerRelationship_whenCalledWithNullRecord_throwsValidationException() {
         UnitOfWork unitOfWork = new UnitOfWork();
         SObject nullRecord;
@@ -519,6 +626,29 @@ private class UnitOfWorkTest {
     }
 
     @isTest
+    private static void registerRelationship_whenParentRecordAlreadyRegisteredForPermanentDeletion_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
+        Account parentAccount = new Account( Id = '001000000000000', Name = 'Parent Account' );
+
+        unitOfWork.registerPermanentlyDeleted( parentAccount );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerRelationship( testContact, Contact.AccountId, parentAccount );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerRelationship, when the parent record has been registered for permanent deletion, should throw an exception' );
+        Assert.areEqual( 'registerRelationship called with a parent record that has been registered for deletion', thrownException.getMessage(), 'registerRelationship, when the parent record has been registered for permanent deletion, should throw a ValidationException' );
+    }
+
+    @isTest
     private static void registerDeleted_whenRecordIsParentOfRegisteredRelationship_throwsValidationException() {
         UnitOfWork unitOfWork = new UnitOfWork();
         Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
@@ -539,6 +669,29 @@ private class UnitOfWorkTest {
 
         Assert.isNotNull( thrownException, 'registerDeleted, when the record is the parent of a registered relationship, should throw an exception' );
         Assert.areEqual( 'registerDeleted called with a record that is the parent of a registered relationship', thrownException.getMessage(), 'registerDeleted, when the record is the parent of a registered relationship, should throw a ValidationException' );
+    }
+
+    @isTest
+    private static void registerPermanentlyDeleted_whenRecordIsParentOfRegisteredRelationship_throwsValidationException() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+        Contact testContact = new Contact( FirstName = 'John', LastName = 'Smith' );
+        Account parentAccount = new Account( Id = '001000000000000', Name = 'Parent Account' );
+
+        unitOfWork.registerRelationship( testContact, Contact.AccountId, parentAccount );
+
+        UnitOfWork.ValidationException thrownException;
+
+        Test.startTest();
+        try {
+            unitOfWork.registerPermanentlyDeleted( parentAccount );
+        }
+        catch ( UnitOfWork.ValidationException ex ) {
+            thrownException = ex;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( thrownException, 'registerPermanentlyDeleted, when the record is the parent of a registered relationship, should throw an exception' );
+        Assert.areEqual( 'registerPermanentlyDeleted called with a record that is the parent of a registered relationship', thrownException.getMessage(), 'registerPermanentlyDeleted, when the record is the parent of a registered relationship, should throw a ValidationException' );
     }
 
     @isTest
@@ -1054,6 +1207,31 @@ private class UnitOfWorkTest {
 
         Assert.isTrue( testAccountsAfter.isEmpty(), 'commitWork, when deleting a record the user has permission for and then one it does not have permission for but has a bypass permission for, should commit successfully - account deleted' );
         Assert.isTrue( testContactsAfter.isEmpty(), 'commitWork, when deleting a record the user has permission for and then one it does not have permission for but has a bypass permission for, should commit successfully - contact deleted' );
+    }
+
+    @isTest
+    private static void commitWork_whenRecordIsRegisteredForPermanentDeletion_deletesAndCallsHardDeleteSuccessfully() {
+        UnitOfWork unitOfWork = new UnitOfWork();
+
+        User testUser = createUserWithPermissionsForSobjectsAndFields( new Set<SobjectType> { Account.SObjectType }, new Set<SobjectField> {} );
+
+        Account testAccount;
+        System.runAs( testUser ) {
+            testAccount = new Account( Name = 'Test Account' );
+            insert testAccount;
+        }
+
+        Test.startTest();
+        System.runAs( testUser ) {
+            unitOfWork.registerPermanentlyDeleted( testAccount );
+            unitOfWork.commitWork();
+        }
+        Test.stopTest();
+
+        List<Account> liveAccountsAfter = [ SELECT Id FROM Account WHERE Id = :testAccount.Id ];
+
+        Assert.isTrue( liveAccountsAfter.isEmpty(), 'commitWork, when a record is registered for permanent deletion, should remove it from normal queries' );
+        Assert.isTrue( unitOfWork.successfullyPermanentlyDeletedRecordIds.contains( testAccount.Id ), 'commitWork, when a record is registered for permanent deletion, should record a successful hard delete result for that record' );
     }
 
     @isTest


### PR DESCRIPTION
## Summary

This PR adds hard delete support to the Apex `UnitOfWork` and tightens a few related API contracts and docs.

### What changed

- Added `registerPermanentlyDeleted( SObject record )`
- Added `registerPermanentlyDeleted( List<SObject> records )`
- Hard delete now works as a two-step commit flow:
  - standard delete first
  - `Database.emptyRecycleBin()` afterward for the records registered for permanent deletion
- Kept normal delete ordering by `SObjectType` for referential safety
- Optimized the hard-delete phase to combine records across types into a minimal number of `emptyRecycleBin` calls
- Preserved `bypassSharing` behavior for the hard-delete path
- Added `@testVisible` tracking of successful `EmptyRecycleBinResult` Ids so hard delete can be tested without depending on immediate `ALL ROWS` purge timing

### Validation and contract updates

- Added matching validation for bulk and single-record `registerPermanentlyDeleted`
- Prevented relationships from being registered against parents already queued for permanent deletion
- Prevented permanent deletion of records that are already the parent of a registered relationship

### Tests

- Added coverage for `registerPermanentlyDeleted`:
  - null record
  - missing Id
  - valid single record
  - valid list
  - null list
  - empty list
  - parent-of-relationship validation
- Added coverage that `commitWork` performs the delete and records a successful hard-delete result
- Updated the test approach to avoid asserting immediate disappearance from `ALL ROWS`, since final physical purge timing is platform-managed

### Documentation

- Updated the README to document:
  - `registerPermanentlyDeleted`
  - hard delete behavior and limitations
  - the distinction between tested `UnitOfWork` behavior and Salesforce-managed purge timing