### PR TITLE
16 - Fix same-type insert dependency handling

### DIFF
--- a/force-app/main/default/classes/UnitOfWork.cls
+++ b/force-app/main/default/classes/UnitOfWork.cls
@@ -340,34 +340,41 @@ public with sharing class UnitOfWork
             return;
         }
 
-        // Collect intra-type priority dependencies: record -> its same-type parent record
-        Map<SObject, SObject> intraTypeParent = new Map<SObject, SObject>();
+        // Collect intra-type priority dependencies only for new same-type parents in this insert batch.
+        // Existing same-type parents already have Ids and do not constrain wave ordering.
+        Set<SObject> recordsToInsertSet = new Set<SObject>( recordsToInsert );
+        Map<SObject, Set<SObject>> intraTypeParentsByRecord = new Map<SObject, Set<SObject>>();
         if ( relationships.relationshipsBySobjectType.containsKey( sobjectType ) ) {
-            for ( Relationship rel : relationships.relationshipsBySobjectType.get( sobjectType ) ) {
-                if ( !secondaryFields.contains( rel.getRelationshipField() ) && rel.getParentRecord().getSObjectType() == sobjectType ) {
-                    intraTypeParent.put( rel.getRecord(), rel.getParentRecord() );
+            for ( Relationship thisRelationship : relationships.relationshipsBySobjectType.get( sobjectType ) ) {
+                if ( secondaryFields.contains( thisRelationship.getRelationshipField() ) || thisRelationship.getParentRecord().getSObjectType() != sobjectType || !recordsToInsertSet.contains( thisRelationship.getParentRecord() ) ) {
+                    continue;
                 }
+
+                if ( !intraTypeParentsByRecord.containsKey( thisRelationship.getRecord() ) ) {
+                    intraTypeParentsByRecord.put( thisRelationship.getRecord(), new Set<SObject>() );
+                }
+                intraTypeParentsByRecord.get( thisRelationship.getRecord() ).add( thisRelationship.getParentRecord() );
             }
         }
 
-        if ( intraTypeParent.isEmpty() ) {
+        if ( intraTypeParentsByRecord.isEmpty() ) {
             // No intra-type dependencies: apply all priority relationships and insert in one batch
-            relationships.applyPriorityRelationshipsForRecords( sobjectType, secondaryFields, new Set<SObject>( recordsToInsert ) );
+            relationships.applyPriorityRelationshipsForRecords( sobjectType, secondaryFields, recordsToInsert );
             insertRecords( recordsToInsert, sobjectType );
         } else {
             // Split into waves so that parent records are inserted before their children
-            List<List<SObject>> waves = topologicalSortRecords( recordsToInsert, intraTypeParent );
+            List<List<SObject>> waves = topologicalSortRecords( recordsToInsert, intraTypeParentsByRecord );
             for ( List<SObject> wave : waves ) {
-                relationships.applyPriorityRelationshipsForRecords( sobjectType, secondaryFields, new Set<SObject>( wave ) );
+                relationships.applyPriorityRelationshipsForRecords( sobjectType, secondaryFields, wave );
                 insertRecords( wave, sobjectType );
             }
         }
     }
 
     // Topologically sorts records within a single SObject type into insertion waves.
-    // intraTypeParent maps each child record to the same-type parent record it depends on.
+    // intraTypeParentsByRecord maps each child record to the same-type parent records it depends on.
     // Returns a list of waves; all records in a wave can be inserted in a single DML statement.
-    private List<List<SObject>> topologicalSortRecords( List<SObject> records, Map<SObject, SObject> intraTypeParent ) {
+    private List<List<SObject>> topologicalSortRecords( List<SObject> records, Map<SObject, Set<SObject>> intraTypeParentsByRecord ) {
         Map<SObject, Integer> inDegreeByRecord = new Map<SObject, Integer>();
         Map<SObject, List<SObject>> childrenByRecord = new Map<SObject, List<SObject>>();
 
@@ -377,13 +384,14 @@ public with sharing class UnitOfWork
         }
 
         for ( SObject record : records ) {
-            if ( intraTypeParent.containsKey( record ) ) {
-                SObject parent = intraTypeParent.get( record );
-                inDegreeByRecord.put( record, inDegreeByRecord.get( record ) + 1 );
-                if ( !childrenByRecord.containsKey( parent ) ) {
-                    childrenByRecord.put( parent, new List<SObject>() );
+            if ( intraTypeParentsByRecord.containsKey( record ) ) {
+                for ( SObject parent : intraTypeParentsByRecord.get( record ) ) {
+                    inDegreeByRecord.put( record, inDegreeByRecord.get( record ) + 1 );
+                    if ( !childrenByRecord.containsKey( parent ) ) {
+                        childrenByRecord.put( parent, new List<SObject>() );
+                    }
+                    childrenByRecord.get( parent ).add( record );
                 }
-                childrenByRecord.get( parent ).add( record );
             }
         }
 
@@ -681,25 +689,27 @@ public with sharing class UnitOfWork
          * Throws RelationshipException if a priority relationship's parent has not yet been inserted.
          * @param sobjectType The sobject type to apply relationships for.
          * @param secondaryFields The set of secondary fields.
-         * @param recordsInWave The set of records to apply relationships for.
+         * @param recordsInWave The list of records to apply relationships for.
          */
-        public void applyPriorityRelationshipsForRecords( SObjectType sobjectType, Set<SObjectField> secondaryFields, Set<SObject> recordsInWave ) {
+        public void applyPriorityRelationshipsForRecords( SObjectType sobjectType, Set<SObjectField> secondaryFields, List<SObject> recordsInWave ) {
             if ( !relationshipsBySobjectType.containsKey( sobjectType ) ) {
                 return;
             }
 
-            for ( Relationship rel : relationshipsBySobjectType.get( sobjectType ) ) {
-                if ( secondaryFields.contains( rel.getRelationshipField() ) ) {
-                    continue;
-                }
-                if ( !recordsInWave.contains( rel.getRecord() ) ) {
-                    continue;
-                }
+            for ( SObject thisRecord : recordsInWave ) {
+                for ( Relationship rel : relationshipsBySobjectType.get( sobjectType ) ) {
+                    if ( rel.getRecord() != thisRecord ) {
+                        continue;
+                    }
+                    if ( secondaryFields.contains( rel.getRelationshipField() ) ) {
+                        continue;
+                    }
 
-                if ( rel.getParentRecord().Id == null ) {
-                    throw new RelationshipException( 'Unable to set relationship ' + rel.getRelationshipField() + ' on record ' + rel.getRecord() + ' because the parent record was not yet inserted.' );
+                    if ( rel.getParentRecord().Id == null ) {
+                        throw new RelationshipException( 'Unable to set relationship ' + rel.getRelationshipField() + ' on record ' + rel.getRecord() + ' because the parent record was not yet inserted.' );
+                    }
+                    rel.getRecord().put( rel.getRelationshipField(), rel.getParentRecord().Id );
                 }
-                rel.getRecord().put( rel.getRelationshipField(), rel.getParentRecord().Id );
             }
         }
     }

--- a/force-app/main/default/classes/UnitOfWorkTest.cls
+++ b/force-app/main/default/classes/UnitOfWorkTest.cls
@@ -1326,6 +1326,181 @@ private class UnitOfWorkTest {
     }
 
     @IsTest
+    private static void commitWork_whenNewRecordHasExistingIntraSobjectParent_commitsSuccessfully() {
+        UnitOfWork uow = new UnitOfWork();
+
+        User testUser = createUserWithPermissionsForSobjectsAndFields( new Set<SobjectType> { Account.SObjectType }, new Set<SobjectField> { Account.ParentId } );
+
+        Account existingParentAccount;
+        System.runAs( testUser ) {
+            existingParentAccount = new Account( Name = 'Existing parent account' );
+            insert existingParentAccount;
+        }
+
+        Account childAccount = new Account( Name = 'Child account' );
+        uow.registerNew( childAccount );
+        uow.registerRelationship( childAccount, Account.ParentId, existingParentAccount );
+
+        Integer dmlStatementsIssuedBefore;
+        Integer dmlRowsIssuedBefore;
+        Integer dmlStatementsIssuedAfter;
+        Integer dmlRowsIssuedAfter;
+        Account childAccountAfter;
+
+        Test.startTest();
+        System.runAs( testUser ) {
+            dmlStatementsIssuedBefore = Limits.getDmlStatements();
+            dmlRowsIssuedBefore = Limits.getDmlRows();
+
+            uow.commitWork();
+
+            dmlStatementsIssuedAfter = Limits.getDmlStatements();
+            dmlRowsIssuedAfter = Limits.getDmlRows();
+
+            childAccountAfter = [ SELECT Id, Name, ParentId FROM Account WHERE Id = :childAccount.Id ];
+        }
+        Test.stopTest();
+
+        Integer expectedExtraDmlStatements = 1 + 1; // 1 is used by SavePoint and 1 by the child account insert.
+        Integer expectedExtraDmlRows = 1; // 1 by the child account insert.
+
+        Assert.areEqual( dmlStatementsIssuedBefore + expectedExtraDmlStatements, dmlStatementsIssuedAfter, 'commitWork, when called with a new record that references an existing intra-sobject parent, should not split the insert into extra waves' );
+        Assert.areEqual( dmlRowsIssuedBefore + expectedExtraDmlRows, dmlRowsIssuedAfter, 'commitWork, when called with a new record that references an existing intra-sobject parent, should issue the minimum required number of DML rows' );
+
+        Assert.isNotNull( childAccountAfter, 'commitWork, when called with a new record that references an existing intra-sobject parent, should commit the child account' );
+        Assert.areEqual( childAccount.Name, childAccountAfter.Name, 'commitWork, when called with a new record that references an existing intra-sobject parent, should preserve the child account name' );
+        Assert.areEqual( existingParentAccount.Id, childAccountAfter.ParentId, 'commitWork, when called with a new record that references an existing intra-sobject parent, should set the parent relationship on the child account' );
+    }
+
+    @IsTest
+    private static void commitWork_whenNewRecordHasMultipleIntraSobjectParents_waitsForAllParentsBeforeInsert() {
+        UnitOfWork uow = new UnitOfWork();
+
+        // We can't ship a second Account self-lookup for tests so we simulate one using the Site field on Account.
+        SobjectField secondParentLookupOnAccount = Account.Site;
+
+        User testUser = createUserWithPermissionsForSobjectsAndFields( new Set<SobjectType> { Account.SObjectType }, new Set<SobjectField> { Account.ParentId, secondParentLookupOnAccount } );
+
+        Account grandparentAccount = new Account( Name = 'Grandparent account' );
+        Account firstParentAccount = new Account( Name = 'First parent account' );
+        Account secondParentAccount = new Account( Name = 'Second parent account' );
+        Account childAccount = new Account( Name = 'Child account' );
+
+        uow.registerNew( grandparentAccount );
+        uow.registerNew( firstParentAccount );
+        uow.registerNew( secondParentAccount );
+        uow.registerNew( childAccount );
+        uow.registerRelationship( firstParentAccount, Account.ParentId, grandparentAccount );
+        uow.registerRelationship( childAccount, Account.ParentId, firstParentAccount );
+        uow.registerRelationship( childAccount, secondParentLookupOnAccount, secondParentAccount );
+
+        Integer dmlStatementsIssuedBefore;
+        Integer dmlRowsIssuedBefore;
+        Integer dmlStatementsIssuedAfter;
+        Integer dmlRowsIssuedAfter;
+        Map<Id,Account> testAccountsAfter;
+
+        Test.startTest();
+        System.runAs( testUser ) {
+            dmlStatementsIssuedBefore = Limits.getDmlStatements();
+            dmlRowsIssuedBefore = Limits.getDmlRows();
+
+            uow.commitWork();
+
+            dmlStatementsIssuedAfter = Limits.getDmlStatements();
+            dmlRowsIssuedAfter = Limits.getDmlRows();
+
+            testAccountsAfter = new Map<Id,Account>([ SELECT Id, Name, ParentId FROM Account WHERE Id IN :new List<Id>{ grandparentAccount.Id, firstParentAccount.Id, secondParentAccount.Id, childAccount.Id } ]);
+        }
+        Test.stopTest();
+
+        Integer expectedExtraDmlStatements = 1 + 3; // 1 is used by SavePoint, 1 by the grandparent and second parent, 1 by the first parent and 1 by the child account.
+        Integer expectedExtraDmlRows = 4; // 1 for each inserted account.
+
+        Assert.areEqual( dmlStatementsIssuedBefore + expectedExtraDmlStatements, dmlStatementsIssuedAfter, 'commitWork, when called with a record that has multiple intra-sobject parents, should issue the minimum required number of DML statements' );
+        Assert.areEqual( dmlRowsIssuedBefore + expectedExtraDmlRows, dmlRowsIssuedAfter, 'commitWork, when called with a record that has multiple intra-sobject parents, should issue the minimum required number of DML rows' );
+
+        Assert.isTrue( testAccountsAfter.size() == 4, 'commitWork, when called with a record that has multiple intra-sobject parents, should commit all accounts' );
+
+        Account grandparentAccountAfter = testAccountsAfter.get( grandparentAccount.Id );
+        Account firstParentAccountAfter = testAccountsAfter.get( firstParentAccount.Id );
+        Account secondParentAccountAfter = testAccountsAfter.get( secondParentAccount.Id );
+        Account childAccountAfter = testAccountsAfter.get( childAccount.Id );
+
+        Assert.areEqual( grandparentAccount.Name, grandparentAccountAfter.Name, 'commitWork, when called with a record that has multiple intra-sobject parents, should commit the grandparent account' );
+        Assert.areEqual( firstParentAccount.Name, firstParentAccountAfter.Name, 'commitWork, when called with a record that has multiple intra-sobject parents, should commit the first parent account' );
+        Assert.areEqual( secondParentAccount.Name, secondParentAccountAfter.Name, 'commitWork, when called with a record that has multiple intra-sobject parents, should commit the second parent account' );
+        Assert.areEqual( childAccount.Name, childAccountAfter.Name, 'commitWork, when called with a record that has multiple intra-sobject parents, should commit the child account' );
+
+        Assert.areEqual( grandparentAccount.Id, firstParentAccountAfter.ParentId, 'commitWork, when called with a record that has multiple intra-sobject parents, should set the grandparent relationship on the first parent account' );
+        Assert.areEqual( firstParentAccount.Id, childAccountAfter.ParentId, 'commitWork, when called with a record that has multiple intra-sobject parents, should set the first parent relationship on the child account' );
+    }
+
+    @IsTest
+    private static void commitWork_whenNewRecordHasSingleFakeRelationshipFieldOnInsert_persistsTheParentIdValue() {
+        UnitOfWork uow = new UnitOfWork();
+
+        // We can't ship a custom text field for tests so we simulate one using the Site field on Account.
+        SobjectField fakeRelationshipField = Account.Site;
+
+        User testUser = createUserWithPermissionsForSobjectsAndFields( new Set<SobjectType> { Account.SObjectType }, new Set<SobjectField> { fakeRelationshipField } );
+
+        Account parentAccount = new Account( Name = 'Parent account' );
+        Account childAccount = new Account( Name = 'Child account' );
+
+        uow.registerNew( parentAccount );
+        uow.registerNew( childAccount );
+        uow.registerRelationship( childAccount, fakeRelationshipField, parentAccount );
+
+        Account childAccountAfter;
+
+        Test.startTest();
+        System.runAs( testUser ) {
+            uow.commitWork();
+            childAccountAfter = [ SELECT Id, Name, Site FROM Account WHERE Id = :childAccount.Id ];
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( childAccountAfter, 'commitWork, when called with a single fake relationship field on insert, should commit the child account' );
+        Assert.areEqual( childAccount.Name, childAccountAfter.Name, 'commitWork, when called with a single fake relationship field on insert, should preserve the child account name' );
+        Assert.areEqual( parentAccount.Id, childAccountAfter.get( fakeRelationshipField ), 'commitWork, when called with a single fake relationship field on insert, should persist the parent Id value to the fake relationship field' );
+    }
+
+    @IsTest
+    private static void commitWork_whenNewRecordHasLookupAndFakeRelationshipFieldOnInsert_persistsBothRelationshipValues() {
+        UnitOfWork uow = new UnitOfWork();
+
+        // We can't ship a custom text field for tests so we simulate one using the Site field on Account.
+        SobjectField fakeRelationshipField = Account.Site;
+
+        User testUser = createUserWithPermissionsForSobjectsAndFields( new Set<SobjectType> { Account.SObjectType }, new Set<SobjectField> { Account.ParentId, fakeRelationshipField } );
+
+        Account lookupParentAccount = new Account( Name = 'Lookup parent account' );
+        Account fakeRelationshipParentAccount = new Account( Name = 'Fake relationship parent account' );
+        Account childAccount = new Account( Name = 'Child account' );
+
+        uow.registerNew( lookupParentAccount );
+        uow.registerNew( fakeRelationshipParentAccount );
+        uow.registerNew( childAccount );
+        uow.registerRelationship( childAccount, Account.ParentId, lookupParentAccount );
+        uow.registerRelationship( childAccount, fakeRelationshipField, fakeRelationshipParentAccount );
+
+        Account childAccountAfter;
+
+        Test.startTest();
+        System.runAs( testUser ) {
+            uow.commitWork();
+            childAccountAfter = [ SELECT Id, Name, ParentId, Site FROM Account WHERE Id = :childAccount.Id ];
+        }
+        Test.stopTest();
+
+        Assert.isNotNull( childAccountAfter, 'commitWork, when called with a lookup and fake relationship field on insert, should commit the child account' );
+        Assert.areEqual( childAccount.Name, childAccountAfter.Name, 'commitWork, when called with a lookup and fake relationship field on insert, should preserve the child account name' );
+        Assert.areEqual( lookupParentAccount.Id, childAccountAfter.ParentId, 'commitWork, when called with a lookup and fake relationship field on insert, should persist the lookup relationship value' );
+        Assert.areEqual( fakeRelationshipParentAccount.Id, childAccountAfter.get( fakeRelationshipField ), 'commitWork, when called with a lookup and fake relationship field on insert, should persist the fake relationship field value' );
+    }
+
+    @IsTest
     private static void commitWork_whenCircularRelationshipsRegistered_splitsDmlAndCommitsSuccessfully() {
         UnitOfWork uow = new UnitOfWork();
 


### PR DESCRIPTION
Fix same-type insert dependency handling for UnitOfWork

Only treat new same-type parents in the current insert batch as wave-ordering dependencies, and track multiple same-type parents per record instead of just one.

Also fix priority relationship application during insert waves so that multiple relationships on the same new record are all applied reliably, including mixed cases with a real lookup field and a text field storing a parent Id.

Add regression tests covering:
- new records with an existing same-type parent
- multiple same-type parent dependencies in one unit of work
- single fake relationship field persistence on insert
- mixed lookup and fake relationship field persistence on insert